### PR TITLE
Feature/ Improve responsive on mobiles views

### DIFF
--- a/src/app/[locale]/dashboard/@board/BoardContainer.tsx
+++ b/src/app/[locale]/dashboard/@board/BoardContainer.tsx
@@ -62,6 +62,8 @@ export default function BoardContainer() {
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
+        backgroundColor: '#f8f8f8',
+        borderRadius: 1,
       }}
     >
       <Box
@@ -70,7 +72,6 @@ export default function BoardContainer() {
           flexDirection: 'column',
           height: '100%',
           p: '.5rem',
-          backgroundColor: '#f8f8f8',
           overflow: 'auto',
         }}
       >
@@ -104,8 +105,9 @@ export default function BoardContainer() {
           display: 'flex',
           justifyContent: 'end',
           alignItems: 'center',
-          pt: '0.5rem',
-          pb: { xs: '0.5rem', sm: '0' },
+          pt: { xs: '0.5rem', sm: 0 },
+          pr: { xs: 1, sm: 1 },
+          pb: { xs: 1, sm: 1 },
         }}
       >
         <Button

--- a/src/app/[locale]/dashboard/@promptForm/PromptForm.tsx
+++ b/src/app/[locale]/dashboard/@promptForm/PromptForm.tsx
@@ -30,7 +30,7 @@ function SubmitButton({ text }: { text: string }) {
   const { pending } = useFormStatus();
 
   return (
-    <Box sx={{ m: 1, position: 'relative' }}>
+    <Box sx={{ position: 'relative' }}>
       <Button
         variant="contained"
         type="submit"
@@ -214,16 +214,17 @@ export function PromptForm() {
               id="prompt-text"
               name="prompt-text"
               multiline
-              rows={5}
+              rows={3}
               required
               InputProps={{
                 inputComponent: 'textarea',
                 style: {
-                  fontSize: '0.8rem',
+                  fontSize: '1rem',
                   color: theme.palette.text.secondary,
+                  paddingTop: '0.5rem',
                 },
               }}
-              inputProps={{ minLength: 5, maxLength: 10 }}
+              inputProps={{ minLength: 5, maxLength: 60 }}
               sx={{ backgroundColor: 'white', fontSize: '0.5rem' }}
             />
           </Box>
@@ -234,7 +235,7 @@ export function PromptForm() {
               display: 'flex',
               flexDirection: 'column',
               flexGrow: 1,
-              mt: '.5rem',
+              my: '.5rem',
             }}
           >
             <FormControlLabel
@@ -245,12 +246,13 @@ export function PromptForm() {
                 <Stack
                   spacing={1}
                   direction="row"
+                  justifyContent="center"
                   useFlexGap
                   flexWrap="nowrap"
                   sx={{
                     alignContent: 'center',
                     alignItems: 'center',
-                    mb: '0.3rem',
+                    justifyContent: 'center',
                   }}
                 >
                   <Typography fontSize={'0.7rem'}>

--- a/src/app/[locale]/dashboard/SavedData/TabsSelector.tsx
+++ b/src/app/[locale]/dashboard/SavedData/TabsSelector.tsx
@@ -40,7 +40,7 @@ export default function TabsSelector(props: {
   };
 
   return (
-    <Box>
+    <Box px={2}>
       <Tabs
         value={value}
         onChange={handleChange}

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -19,14 +19,14 @@ const sxStyles = {
     flexDirection: { xs: 'column' },
     gridTemplateColumns: { xs: '1fr', md: '1fr 2fr', lg: '1fr 3fr' },
     gridTemplateRows: {
-      xs: `max-content max-content calc(100% - ${menuBarHeight}px);`,
+      xs: `max-content calc(100% - ${menuBarHeight}px) max-content`,
       md: 'auto 1fr',
     },
 
     gridTemplateAreas: {
       xs: `"title"
-    "sidebar"
-    "board"`,
+    "board"
+    "sidebar"`,
       md: `"title board"
   "sidebar board"`,
     },
@@ -61,7 +61,7 @@ export default function Dashboard(props: {
         <Box py={{ xs: xsPadding, md: mdPadding }} className={styles.titleBox}>
           {props.navbar}
         </Box>
-        <Box sx={sxStyles.sidebar}>
+        <Box pb={{ xs: xsSpacing, md: mdPadding }} sx={sxStyles.sidebar}>
           <Box className={styles.controls}>{props.promptForm}</Box>
           <div className={styles.controls}>
             <SavedData
@@ -70,7 +70,7 @@ export default function Dashboard(props: {
             />
           </div>
         </Box>
-        <Box pb={{ xs: xsPadding, md: mdPadding }} className={styles.board}>
+        <Box pb={{ xs: xsSpacing, md: mdPadding }} className={styles.board}>
           {props.board}
         </Box>
         {props.children}

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -7,8 +7,8 @@ const xsSpacing = 3;
 const mdSpacing = 2;
 const lgSpacing = 2;
 
-const xsMargin = 1;
-const mdMargin = 0;
+const xsPadding = 1;
+const mdPadding = 0;
 
 const menuBarHeight = 56;
 const sxStyles = {
@@ -58,7 +58,7 @@ export default function Dashboard(props: {
         sx={sxStyles.dashboardContainer}
         className={styles.dashboardContainer}
       >
-        <Box py={{ xs: xsMargin, md: mdMargin }} className={styles.titleBox}>
+        <Box py={{ xs: xsPadding, md: mdPadding }} className={styles.titleBox}>
           {props.navbar}
         </Box>
         <Box sx={sxStyles.sidebar}>
@@ -70,7 +70,7 @@ export default function Dashboard(props: {
             />
           </div>
         </Box>
-        <Box pb={{ xs: xsMargin, md: mdMargin }} className={styles.board}>
+        <Box pb={{ xs: xsPadding, md: mdPadding }} className={styles.board}>
           {props.board}
         </Box>
         {props.children}

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -3,9 +3,12 @@ import * as React from 'react';
 import styles from './styles.module.css';
 import SavedData from './SavedData/SavedData';
 
-const xsSpacing = 1;
+const xsSpacing = 3;
 const mdSpacing = 2;
-const lgSpacing = 3;
+const lgSpacing = 2;
+
+const xsMargin = 1;
+const mdMargin = 0;
 
 const menuBarHeight = 56;
 const sxStyles = {
@@ -28,11 +31,12 @@ const sxStyles = {
   "sidebar board"`,
     },
     columnGap: { xs: 0, md: mdSpacing, lg: lgSpacing },
-    rowGap: { xs: xsSpacing, md: mdSpacing, lg: lgSpacing },
+    rowGap: { xs: 0, md: mdSpacing, lg: lgSpacing },
   },
   sidebar: {
     display: 'flex',
     flexDirection: 'column',
+    justifyContent: 'space-between',
     overflow: 'auto',
     rowGap: { xs: xsSpacing, md: mdSpacing, lg: lgSpacing },
     borderRadius: '5px',
@@ -54,7 +58,7 @@ export default function Dashboard(props: {
         sx={sxStyles.dashboardContainer}
         className={styles.dashboardContainer}
       >
-        <Box py={{ xs: xsSpacing, md: 0 }} className={styles.titleBox}>
+        <Box py={{ xs: xsMargin, md: mdMargin }} className={styles.titleBox}>
           {props.navbar}
         </Box>
         <Box sx={sxStyles.sidebar}>
@@ -66,7 +70,7 @@ export default function Dashboard(props: {
             />
           </div>
         </Box>
-        <Box pb={{ xs: xsSpacing, md: 0 }} className={styles.board}>
+        <Box pb={{ xs: xsMargin, md: mdMargin }} className={styles.board}>
           {props.board}
         </Box>
         {props.children}

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -14,7 +14,7 @@ const sxStyles = {
     overflowY: { xs: 'scroll', sm: 'unset' },
     alignContent: { xs: 'flex-start', sm: 'inherit' },
     flexDirection: { xs: 'column' },
-    gridTemplateColumns: { xs: '1fr', sm: '1fr 2fr', md: '1fr 3fr' },
+    gridTemplateColumns: { xs: '1fr', sm: '1fr 2fr', lg: '1fr 3fr' },
     gridTemplateRows: {
       xs: `max-content max-content calc(100% - ${menuBarHeight}px);`,
       sm: 'auto 1fr',
@@ -27,8 +27,8 @@ const sxStyles = {
       sm: `"title board"
   "sidebar board"`,
     },
-    columnGap: { xs: 0, sm: smSpacing, md: mdSpacing },
-    rowGap: { xs: xsSpacing, sm: smSpacing, md: mdSpacing },
+    columnGap: { xs: 0, sm: smSpacing, lg: mdSpacing },
+    rowGap: { xs: xsSpacing, sm: smSpacing, lg: mdSpacing },
   },
   sidebar: {
     display: 'flex',
@@ -47,9 +47,9 @@ export default function Dashboard(props: {
   board: React.ReactNode;
 }) {
   return (
-    <Box py={{ xs: 0, sm: 2, md: 3 }} className={styles.dashboardBox}>
+    <Box py={{ xs: 0, sm: 2, lg: 3 }} className={styles.dashboardBox}>
       <Box
-        px={{ xs: 2, md: 4 }}
+        px={{ xs: 2, lg: 4 }}
         sx={sxStyles.dashboardContainer}
         className={styles.dashboardContainer}
       >

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -4,37 +4,37 @@ import styles from './styles.module.css';
 import SavedData from './SavedData/SavedData';
 
 const xsSpacing = 1;
-const smSpacing = 2;
-const mdSpacing = 3;
+const mdSpacing = 2;
+const lgSpacing = 3;
 
 const menuBarHeight = 56;
 const sxStyles = {
   dashboardContainer: {
     display: 'grid',
-    overflowY: { xs: 'scroll', sm: 'unset' },
-    alignContent: { xs: 'flex-start', sm: 'inherit' },
+    overflowY: { xs: 'scroll', md: 'unset' },
+    alignContent: { xs: 'flex-start', md: 'inherit' },
     flexDirection: { xs: 'column' },
-    gridTemplateColumns: { xs: '1fr', sm: '1fr 2fr', lg: '1fr 3fr' },
+    gridTemplateColumns: { xs: '1fr', md: '1fr 2fr', lg: '1fr 3fr' },
     gridTemplateRows: {
       xs: `max-content max-content calc(100% - ${menuBarHeight}px);`,
-      sm: 'auto 1fr',
+      md: 'auto 1fr',
     },
 
     gridTemplateAreas: {
       xs: `"title"
     "sidebar"
     "board"`,
-      sm: `"title board"
+      md: `"title board"
   "sidebar board"`,
     },
-    columnGap: { xs: 0, sm: smSpacing, lg: mdSpacing },
-    rowGap: { xs: xsSpacing, sm: smSpacing, lg: mdSpacing },
+    columnGap: { xs: 0, md: mdSpacing, lg: lgSpacing },
+    rowGap: { xs: xsSpacing, md: mdSpacing, lg: lgSpacing },
   },
   sidebar: {
     display: 'flex',
     flexDirection: 'column',
     overflow: 'auto',
-    rowGap: { xs: xsSpacing, sm: smSpacing, md: mdSpacing },
+    rowGap: { xs: xsSpacing, md: mdSpacing, lg: lgSpacing },
     borderRadius: '5px',
   },
 };
@@ -48,13 +48,13 @@ export default function Dashboard(props: {
   board: React.ReactNode;
 }) {
   return (
-    <Box py={{ xs: 0, sm: 2, lg: 3 }} className={styles.dashboardBox}>
+    <Box py={{ xs: 0, md: 2, lg: 3 }} className={styles.dashboardBox}>
       <Box
         px={{ xs: 2, lg: 4 }}
         sx={sxStyles.dashboardContainer}
         className={styles.dashboardContainer}
       >
-        <Box py={{ xs: xsSpacing, sm: 0 }} className={styles.titleBox}>
+        <Box py={{ xs: xsSpacing, md: 0 }} className={styles.titleBox}>
           {props.navbar}
         </Box>
         <Box sx={sxStyles.sidebar}>
@@ -66,7 +66,7 @@ export default function Dashboard(props: {
             />
           </div>
         </Box>
-        <Box pb={{ xs: xsSpacing, sm: 0 }} className={styles.board}>
+        <Box pb={{ xs: xsSpacing, md: 0 }} className={styles.board}>
           {props.board}
         </Box>
         {props.children}

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -35,6 +35,7 @@ const sxStyles = {
     flexDirection: 'column',
     overflow: 'auto',
     rowGap: { xs: xsSpacing, sm: smSpacing, md: mdSpacing },
+    borderRadius: '5px',
   },
 };
 


### PR DESCRIPTION
In this PR
-[Extend the grey bg of the board contain the 'Export to Cboard' button to get more space for the sidebar](https://github.com/cboard-org/cboard-ai-builder/commit/8ea3e2b88bad14495acf68cf4c284a656d51f49b)
-[Add border radius to the board background](https://github.com/cboard-org/cboard-ai-builder/commit/42206eb9974a4e8bcbe1f55da8adebc8d9d08eb7)
-[Use lg breakpoint to change columns width on layout](https://github.com/cboard-org/cboard-ai-builder/commit/fc78884c622d62e1604b75310d2f4248d8dd256a)
-[Add padding x to the tabsSelector](https://github.com/cboard-org/cboard-ai-builder/commit/c707d1f8a6bfd06c05d1275c170cfae33e489ed6)
-[Improve Prompt component](https://github.com/cboard-org/cboard-ai-builder/commit/f5bd09527478dfe4fdae18ba000dd19976ac03c0)
-[Use Mobile view until md breakpoint](https://github.com/cboard-org/cboard-ai-builder/commit/620b58f9a999c3e1e0cbe53858d1554c455620e3)
-[Put the Board first on the mobile view.](https://github.com/cboard-org/cboard-ai-builder/commit/010b29adaea397829c14f1bd8cf83ce0e77352cb)