### PR TITLE
Fix/credentials singin success redirect

### DIFF
--- a/src/app/[locale]/signin/Login/Dialog.tsx
+++ b/src/app/[locale]/signin/Login/Dialog.tsx
@@ -37,7 +37,7 @@ export default function Dialog({
           const response = await signIn('credentials', {
             email: formData.get('email') as string,
             password: formData.get('password') as string,
-            redirect: false,
+            callbackUrl: '/dashboard',
           });
           if (response?.ok) {
             // parent Page will do a redirect if user is logged-in to the callback url

--- a/src/app/[locale]/signin/Login/Dialog.tsx
+++ b/src/app/[locale]/signin/Login/Dialog.tsx
@@ -8,7 +8,6 @@ import MUIButton from '@mui/material/Button';
 import { useState } from 'react';
 import DialogActions from '@mui/material/DialogActions';
 import { signIn } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
 import Alert from '@mui/material/Alert';
 import { useTranslations } from 'next-intl';
 import { styles } from './styles';
@@ -22,7 +21,6 @@ export default function Dialog({
   const t = useTranslations('SignIn.LoginDialog');
   const [error, setError] = useState<string | false>(false);
   const [loading, setLoading] = useState(false);
-  const { refresh } = useRouter();
   return (
     <MUIDialog
       open={open}
@@ -39,11 +37,7 @@ export default function Dialog({
             password: formData.get('password') as string,
             callbackUrl: '/dashboard',
           });
-          if (response?.ok) {
-            // parent Page will do a redirect if user is logged-in to the callback url
-            refresh();
-            return;
-          }
+          if (response?.ok) return;
           if (response?.error) {
             setError(t('errorMessage'));
           }


### PR DESCRIPTION
After a credential login use the callback URL to avoid  /en-US/en-US/dashboard redirect
close #103 