### PR TITLE
Fix generationPending state after board generation

### DIFF
--- a/src/app/[locale]/dashboard/[id]/@board/BoardContainer.tsx
+++ b/src/app/[locale]/dashboard/[id]/@board/BoardContainer.tsx
@@ -128,15 +128,21 @@ const useSetInitialBoard = ({
   remoteBoard: BoardRecord | null;
   id: string;
 }) => {
-  const [setBoard, stashedDashboard, hydrated, setBoardIsUpToDate] =
-    useBoundStore(
-      useShallow((state) => [
-        state.setBoard,
-        state.stashedDashboard,
-        state.hydrated,
-        state.setBoardIsUpToDate,
-      ]),
-    );
+  const [
+    setBoard,
+    stashedDashboard,
+    hydrated,
+    setBoardIsUpToDate,
+    setGenerationPending,
+  ] = useBoundStore(
+    useShallow((state) => [
+      state.setBoard,
+      state.stashedDashboard,
+      state.hydrated,
+      state.setBoardIsUpToDate,
+      state.setGenerationPending,
+    ]),
+  );
   useEffect(() => {
     if (remoteBoard) {
       setBoard(remoteBoard);
@@ -148,10 +154,13 @@ const useSetInitialBoard = ({
   const router = useRouter();
   useEffect(() => {
     if (stashedBoard)
-      if (id === STASHED_CONTENT_ID) return setBoard(stashedBoard);
+      if (id === STASHED_CONTENT_ID) {
+        setBoard(stashedBoard);
+        setGenerationPending(false);
+      }
     if (id === STASHED_CONTENT_ID && !stashedBoard && hydrated)
       router.push(`/dashboard/${INITIAL_CONTENT_ID}`);
-  }, [id, setBoard, stashedBoard, router, hydrated]);
+  }, [id, setBoard, stashedBoard, router, hydrated, setGenerationPending]);
 
   return;
 };

--- a/src/app/[locale]/dashboard/[id]/hooks/useIsInitialContentView.ts
+++ b/src/app/[locale]/dashboard/[id]/hooks/useIsInitialContentView.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { usePathname } from '@/navigation';
+import { INITIAL_CONTENT_ID } from '@/dashboard/constants';
+
+function useIsInitialContentView() {
+  const pathname = usePathname();
+
+  const isInitialContentView = useMemo(() => {
+    const parts = pathname.split('/');
+    const boardId = parts[parts.length - 1];
+    return boardId === INITIAL_CONTENT_ID;
+  }, [pathname]);
+
+  return isInitialContentView;
+}
+
+export default useIsInitialContentView;

--- a/src/components/DataItem/DataItem.tsx
+++ b/src/components/DataItem/DataItem.tsx
@@ -15,6 +15,7 @@ import { INITIAL_CONTENT_ID } from '@/app/[locale]/dashboard/[id]/constants';
 import { useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import useIsInitialContentView from '@/app/[locale]/dashboard/[id]/hooks/useIsInitialContentView';
+import { usePathname } from 'next/navigation';
 
 export type BaseDataItemType = {
   id: string;
@@ -44,8 +45,14 @@ export default function DataItem<DataType extends BaseDataItemType>({
   const [isRedirecting, setIsRedirecting] = useState(false);
   const isInitialContentView = useIsInitialContentView();
 
+  const pathname = usePathname();
+
   const onEdit = () => {
-    if (!isInitialContentView || data.isSavedBoard) setIsRedirecting(true);
+    if (
+      (!isInitialContentView || data.isSavedBoard) &&
+      !pathname.includes(data.id)
+    )
+      setIsRedirecting(true);
     setPrompt({
       description,
       rows,

--- a/src/components/DataItem/DataItem.tsx
+++ b/src/components/DataItem/DataItem.tsx
@@ -12,6 +12,10 @@ import { PromptRecord } from '@/commonTypes/Prompt';
 import { useShallow } from 'zustand/react/shallow';
 import { Link } from '@/navigation';
 import { INITIAL_CONTENT_ID } from '@/app/[locale]/dashboard/[id]/constants';
+import { useState } from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
+import useIsInitialContentView from '@/app/[locale]/dashboard/[id]/hooks/useIsInitialContentView';
+
 export type BaseDataItemType = {
   id: string;
   isSavedBoard?: boolean;
@@ -37,8 +41,11 @@ export default function DataItem<DataType extends BaseDataItemType>({
   const [setPrompt, isGenerationPending] = useBoundStore(
     useShallow((state) => [state.setPrompt, state.isGenerationPending]),
   );
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const isInitialContentView = useIsInitialContentView();
 
   const onEdit = () => {
+    if (!isInitialContentView || data.isSavedBoard) setIsRedirecting(true);
     setPrompt({
       description,
       rows,
@@ -65,7 +72,11 @@ export default function DataItem<DataType extends BaseDataItemType>({
               onClick={() => onEdit()}
               size="small"
             >
-              <EditOutlined fontSize="small" />
+              {isRedirecting ? (
+                <CircularProgress size={24} />
+              ) : (
+                <EditOutlined fontSize="small" />
+              )}
             </IconButton>
           </Link>
           <IconButton


### PR DESCRIPTION
This pull request fixes the issue with the generationPending state not being updated correctly after board generation. It also adds a new hook called useIsInitialContentView and a CircularProgress component for DataItem Link redirection.