### PR TITLE
Refactor GenerateButton component to GenerateIcon

### DIFF
--- a/src/components/Symbol/GenerateIcon.tsx
+++ b/src/components/Symbol/GenerateIcon.tsx
@@ -1,13 +1,10 @@
-import IconButton from '@mui/material/IconButton';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import Tooltip from '@mui/material/Tooltip';
 
-export default function GenerateButton() {
+export default function GenerateIcon() {
   return (
     <Tooltip title={'Create a Pictogram'}>
-      <IconButton>
-        <AutoAwesomeIcon />
-      </IconButton>
+      <AutoAwesomeIcon />
     </Tooltip>
   );
 }

--- a/src/components/Symbol/Symbol.tsx
+++ b/src/components/Symbol/Symbol.tsx
@@ -8,7 +8,7 @@ import { useShallow } from 'zustand/react/shallow';
 import CircularProgress from '@mui/material/CircularProgress';
 import { usePathname } from '@/navigation';
 import { STASHED_CONTENT_ID } from '@/app/[locale]/dashboard/[id]/constants';
-import GenerateButton from './GenerateButton';
+import GenerateIcon from './GenerateIcon';
 import Box from '@mui/material/Box';
 import CircleIcon from '@mui/icons-material/Circle';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
@@ -203,7 +203,7 @@ export default function Symbol({
 
       {!src && !isPictoGenerationActive && !isChangingPicto && (
         <div className={style.SymbolEmptyImageContainer}>
-          <GenerateButton />
+          <GenerateIcon />
         </div>
       )}
 


### PR DESCRIPTION
This pull request renames the GenerateButton component to GenerateIcon and removes the IconButton import from the component.  

close #166