### PR TITLE
Feature / Acces PassCode

### DIFF
--- a/src/app/[locale]/signin/AuthSection/AuthSection.tsx
+++ b/src/app/[locale]/signin/AuthSection/AuthSection.tsx
@@ -1,0 +1,51 @@
+'use client';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
+import Login from '@/app/[locale]/signin/Login/Login';
+import Alert from '@/components/Alert/Alert';
+import OAuthButton from '@/app/[locale]/signin/OAuth/Button';
+import { styles } from './styles';
+import { useTranslations } from 'next-intl';
+import { ClientSafeProvider } from 'next-auth/react';
+import { useState } from 'react';
+import PassCode from '../PassCode/PassCode';
+
+export default function AuthSection({
+  errorMessage,
+  oauthProviders,
+}: {
+  errorMessage: string;
+  oauthProviders: ClientSafeProvider[];
+}) {
+  const t = useTranslations('SignIn');
+  const [isAuthorized, setIsAuthorized] = useState(false);
+  return (
+    <Box sx={styles.mainContainer}>
+      <Box sx={styles.welcomeTextContainer}>
+        <Typography sx={styles.holaText}>{t('hello')}</Typography>
+        <Typography sx={styles.welcomeText}>{t('welcome')}</Typography>
+      </Box>
+      {isAuthorized ? (
+        <>
+          <Login />
+
+          <Button fullWidth variant="contained" size="large">
+            {t('signUpButton')}
+          </Button>
+
+          <Divider flexItem sx={styles.divider} variant="fullWidth" />
+
+          {errorMessage && <Alert messages={t('errorMessage')} />}
+
+          {oauthProviders.map((provider) => (
+            <OAuthButton key={provider.id} provider={provider} />
+          ))}
+        </>
+      ) : (
+        <PassCode setIsAuthorized={setIsAuthorized} />
+      )}
+    </Box>
+  );
+}

--- a/src/app/[locale]/signin/AuthSection/AuthSection.tsx
+++ b/src/app/[locale]/signin/AuthSection/AuthSection.tsx
@@ -27,7 +27,7 @@ export default function AuthSection({
         <Typography sx={styles.holaText}>{t('hello')}</Typography>
         <Typography sx={styles.welcomeText}>{t('welcome')}</Typography>
       </Box>
-      {isAuthorized ? (
+      {isAuthorized || errorMessage ? (
         <>
           <Login />
 

--- a/src/app/[locale]/signin/AuthSection/AuthSection.tsx
+++ b/src/app/[locale]/signin/AuthSection/AuthSection.tsx
@@ -11,6 +11,7 @@ import { useTranslations } from 'next-intl';
 import { ClientSafeProvider } from 'next-auth/react';
 import { useState } from 'react';
 import PassCode from '../PassCode/PassCode';
+import { getCboardSignupURL } from './action';
 
 export default function AuthSection({
   errorMessage,
@@ -21,6 +22,16 @@ export default function AuthSection({
 }) {
   const t = useTranslations('SignIn');
   const [isAuthorized, setIsAuthorized] = useState(false);
+
+  const onSignUpClick = async () => {
+    try {
+      const { URL } = await getCboardSignupURL();
+      return window.open(URL, '_blank');
+    } catch (error) {
+      return;
+    }
+  };
+
   return (
     <Box sx={styles.mainContainer}>
       <Box sx={styles.welcomeTextContainer}>
@@ -31,7 +42,12 @@ export default function AuthSection({
         <>
           <Login />
 
-          <Button fullWidth variant="contained" size="large">
+          <Button
+            fullWidth
+            variant="contained"
+            size="large"
+            onClick={onSignUpClick}
+          >
             {t('signUpButton')}
           </Button>
 

--- a/src/app/[locale]/signin/AuthSection/action.ts
+++ b/src/app/[locale]/signin/AuthSection/action.ts
@@ -1,0 +1,8 @@
+'use server';
+
+export async function getCboardSignupURL() {
+  const URL = `${process.env.CBOARD_APP_URL_!}login-signup`;
+  return {
+    URL,
+  };
+}

--- a/src/app/[locale]/signin/AuthSection/styles.ts
+++ b/src/app/[locale]/signin/AuthSection/styles.ts
@@ -18,10 +18,9 @@ export const styles = {
   holaText: {
     fontWeight: 600,
     fontSize: { xs: '32px', md: '48px' },
-    color: '#181717',
     pb: '16px',
   },
-  welcomeText: { color: '#2B2B2B', fontSize: '16px' },
+  welcomeText: { fontSize: '16px' },
   divider: {
     my: { xs: 2, md: 4 },
     borderColor: { xs: '#6D6D6D', md: '#C9C9C9' },

--- a/src/app/[locale]/signin/AuthSection/styles.ts
+++ b/src/app/[locale]/signin/AuthSection/styles.ts
@@ -1,0 +1,29 @@
+import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
+
+export const styles = {
+  mainContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    maxWidth: '370px',
+    alignSelf: 'flex-end',
+  },
+  welcomeTextContainer: {
+    alignSelf: { xs: 'center', md: 'start' },
+    textAlign: { xs: 'center', md: 'inherit' },
+  },
+  holaText: {
+    fontWeight: 600,
+    fontSize: { xs: '32px', md: '48px' },
+    color: '#181717',
+    pb: '16px',
+  },
+  welcomeText: { color: '#2B2B2B', fontSize: '16px' },
+  divider: {
+    my: { xs: 2, md: 4 },
+    borderColor: { xs: '#6D6D6D', md: '#C9C9C9' },
+  },
+} satisfies Record<string, SxProps>;

--- a/src/app/[locale]/signin/Login/styles.ts
+++ b/src/app/[locale]/signin/Login/styles.ts
@@ -3,5 +3,5 @@ import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
 export const styles = {
   dialogTitle: { pb: 2 },
   dialogForgotPasswordContainer: { px: 2, pb: 2 },
-  button: { backgroundColor: '#fff' },
+  button: { backgroundColor: '' },
 } satisfies Record<string, SxProps>;

--- a/src/app/[locale]/signin/PassCode/PassCode.tsx
+++ b/src/app/[locale]/signin/PassCode/PassCode.tsx
@@ -1,0 +1,100 @@
+import Box from '@mui/material/Box';
+import { styles } from './styles';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import validateCode from './action';
+import { useFormState, useFormStatus } from 'react-dom';
+import { useEffect, useState } from 'react';
+import Alert from '@/components/Alert/Alert';
+import { useTranslations } from 'next-intl';
+
+const SubmitButton = ({ isFormValid }: { isFormValid: boolean }) => {
+  const { pending } = useFormStatus();
+  const t = useTranslations('SignIn.PassCode');
+  return (
+    <Button
+      variant="contained"
+      sx={styles.submitButton}
+      disabled={pending || !isFormValid}
+      type="submit"
+    >
+      {t('submit')}
+    </Button>
+  );
+};
+
+const initialState = {
+  isAuthorized: false,
+  errorMessage: '',
+  error: false,
+};
+
+export default function PassCode({
+  setIsAuthorized,
+}: {
+  setIsAuthorized: (value: boolean) => void;
+}) {
+  const t = useTranslations('SignIn.PassCode');
+
+  const [state, formAction] = useFormState(validateCode, initialState);
+  const [code, setCode] = useState('');
+  const [email, setEmail] = useState('');
+  const [isCodeValid, setIsCodeValid] = useState(false);
+  const [isEmailValid, setIsEmailValid] = useState(false);
+
+  useEffect(() => {
+    setIsCodeValid(code.length === 6);
+    setIsEmailValid(email.includes('@') && email.includes('.'));
+  }, [code, email]);
+
+  const isFormValid = isCodeValid && isEmailValid;
+
+  useEffect(() => {
+    if (state.isAuthorized) {
+      setIsAuthorized(true);
+    }
+  }, [state.isAuthorized, setIsAuthorized]);
+
+  return (
+    <Box sx={styles.container}>
+      <form action={formAction} style={{ width: '100% ' }}>
+        <Box sx={styles.textFieldsContainer}>
+          <TextField
+            label={t('code')}
+            name="code"
+            variant="outlined"
+            value={code}
+            onChange={(e) => setCode(e.target.value.toUpperCase())}
+            sx={{ ...styles.textField, textTransform: 'uppercase' }}
+            required
+            type="text"
+            slotProps={{
+              htmlInput: {
+                maxLength: 6,
+                minLength: 6,
+                style: { textTransform: 'uppercase' },
+              },
+            }}
+          />
+          <TextField
+            label={t('email')}
+            name="email"
+            variant="outlined"
+            type="email"
+            sx={styles.textField}
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            helperText={t('emailHelperText')}
+          />
+          <SubmitButton isFormValid={isFormValid} />
+        </Box>
+      </form>
+      {state.error && (
+        <Box sx={styles.alert}>
+          <Alert messages={t('invalidCredentials')} />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/app/[locale]/signin/PassCode/action.tsx
+++ b/src/app/[locale]/signin/PassCode/action.tsx
@@ -1,4 +1,6 @@
+'use server';
 import { z } from 'zod';
+import { verifyPasscode } from '@/db/services/PassCode/service';
 
 const schema = z.object({
   email: z.string().email(),
@@ -17,8 +19,6 @@ export default async function validateCode(
     email: formData.get('email'),
     code: formData.get('code'),
   });
-
-  // Return early if the form data is invalid
   if (!validatedFields.success) {
     return {
       isAuthorized: false,
@@ -27,12 +27,20 @@ export default async function validateCode(
       error: true,
     };
   }
-
+  const response = await verifyPasscode(
+    validatedFields.data.code,
+    validatedFields.data.email,
+  );
+  if (!response.success) {
+    return {
+      isAuthorized: false,
+      errorMessage: response.message,
+      error: true,
+    };
+  }
   return {
     isAuthorized: true,
     errorMessage: '',
     error: false,
   };
-
-  // Mutate data
 }

--- a/src/app/[locale]/signin/PassCode/action.tsx
+++ b/src/app/[locale]/signin/PassCode/action.tsx
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+const schema = z.object({
+  email: z.string().email(),
+  code: z.string({ message: 'Not valid code' }).min(6).max(6),
+});
+
+export default async function validateCode(
+  prevState: {
+    isAuthorized: boolean;
+    errorMessage: string;
+    error: boolean;
+  },
+  formData: FormData,
+) {
+  const validatedFields = schema.safeParse({
+    email: formData.get('email'),
+    code: formData.get('code'),
+  });
+
+  // Return early if the form data is invalid
+  if (!validatedFields.success) {
+    return {
+      isAuthorized: false,
+      //   errorMessage: validatedFields.error.flatten().fieldErrors,
+      errorMessage: 'Not valid code or email',
+      error: true,
+    };
+  }
+
+  return {
+    isAuthorized: true,
+    errorMessage: '',
+    error: false,
+  };
+
+  // Mutate data
+}

--- a/src/app/[locale]/signin/PassCode/styles.ts
+++ b/src/app/[locale]/signin/PassCode/styles.ts
@@ -1,0 +1,39 @@
+import { SxProps } from '@mui/system/styleFunctionSx/styleFunctionSx';
+
+export const styles = {
+  container: {
+    height: '100%',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: { xs: 'white', md: 'none' },
+    padding: { xs: 3, md: 0 },
+    borderRadius: { xs: 7, md: 0 },
+  },
+  textFieldsContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    width: '100%',
+    borderRadius: 7,
+    flex: 1,
+  },
+  textField: {
+    width: '100%',
+    flex: 1,
+  },
+  submitButton: {
+    width: '100%',
+    backgroundColor: 'primary.main',
+    color: 'primary.contrastText',
+    '&:hover': {
+      backgroundColor: 'secondary.dark',
+    },
+  },
+  alert: {
+    width: '100%',
+    marginTop: 2,
+  },
+} satisfies Record<string, SxProps>;

--- a/src/app/[locale]/signin/PassCode/styles.ts
+++ b/src/app/[locale]/signin/PassCode/styles.ts
@@ -8,7 +8,7 @@ export const styles = {
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: { xs: 'white', md: 'none' },
+    backgroundColor: { xs: 'secondary.contrastText', md: 'transparent' },
     padding: { xs: 3, md: 0 },
     borderRadius: { xs: 7, md: 0 },
   },

--- a/src/app/[locale]/signin/Signin.tsx
+++ b/src/app/[locale]/signin/Signin.tsx
@@ -3,14 +3,9 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Divider from '@mui/material/Divider';
-import OAuthButton from './OAuth/Button';
 import { getProviders } from 'next-auth/react';
 import InternalLink from '@/components/InternalLink/InternalLink';
 import Image from 'next/image';
-import Login from '@/app/[locale]/signin/Login/Login';
-import Alert from '@/components/Alert/Alert';
 import {
   NextIntlClientProvider,
   useMessages,
@@ -20,6 +15,7 @@ import pick from 'lodash.pick';
 import { styles } from './styles';
 import SvgIcon from '@mui/material/SvgIcon';
 import { BRAND_COLOR } from './constants';
+import AuthSection from './AuthSection/AuthSection';
 
 export default function Signin({
   errorMessage,
@@ -125,28 +121,10 @@ export default function Signin({
                   </Typography>
                 </Stack>
               </Box>
-              <Box sx={styles.mainContainer}>
-                <Box sx={styles.welcomeTextContainer}>
-                  <Typography sx={styles.holaText}>{t('hello')}</Typography>
-                  <Typography sx={styles.welcomeText}>
-                    {t('welcome')}
-                  </Typography>
-                </Box>
-
-                <Login />
-
-                <Button fullWidth variant="contained" size="large">
-                  {t('signUpButton')}
-                </Button>
-
-                <Divider flexItem sx={styles.divider} variant="fullWidth" />
-
-                {errorMessage && <Alert messages={t('errorMessage')} />}
-
-                {oauthProviders.map((provider) => (
-                  <OAuthButton key={provider.id} provider={provider} />
-                ))}
-              </Box>
+              <AuthSection
+                oauthProviders={oauthProviders}
+                errorMessage={errorMessage}
+              />
               <Box sx={styles.bottomLinks}>
                 <InternalLink href={'#'}>{t('privacyPolicy')}</InternalLink>
                 <InternalLink href={'#'}>{t('terms')}</InternalLink>

--- a/src/app/[locale]/signin/styles.ts
+++ b/src/app/[locale]/signin/styles.ts
@@ -3,7 +3,7 @@ import { PURPLE } from './constants';
 
 export const styles = {
   root: {
-    background: { xs: PURPLE, md: 'white' },
+    background: { xs: PURPLE, md: 'transparent' },
     width: '100%',
     height: '100%',
     py: { xs: 0, md: 2 },

--- a/src/app/[locale]/signin/styles.ts
+++ b/src/app/[locale]/signin/styles.ts
@@ -44,16 +44,6 @@ export const styles = {
     width: 'min-content',
     maxWidth: '100%',
   },
-  mainContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-    maxWidth: '370px',
-    alignSelf: 'flex-end',
-  },
   brandLogoXs: {
     display: { xs: 'flex', md: 'none' },
     justifyContent: 'center',
@@ -81,21 +71,6 @@ export const styles = {
     flexDirection: 'column',
     alignItems: 'center',
     alignContent: { xs: 'flex-end', md: 'unset' },
-  },
-  welcomeTextContainer: {
-    alignSelf: { xs: 'center', md: 'start' },
-    textAlign: { xs: 'center', md: 'inherit' },
-  },
-  holaText: {
-    fontWeight: 600,
-    fontSize: { xs: '32px', md: '48px' },
-    color: '#181717',
-    pb: '16px',
-  },
-  welcomeText: { color: '#2B2B2B', fontSize: '16px' },
-  divider: {
-    my: { xs: 2, md: 4 },
-    borderColor: { xs: '#6D6D6D', md: '#C9C9C9' },
   },
   bottomLinks: {
     width: '100%',

--- a/src/app/api/helpers.ts
+++ b/src/app/api/helpers.ts
@@ -1,0 +1,8 @@
+import { headers } from 'next/headers';
+
+export function validateBearerToken(): boolean {
+  const headersList = headers();
+  const token = headersList.get('Authorization')?.split(' ')[1] || '';
+
+  return token === process.env.INTERNAL_API_KEY;
+}

--- a/src/app/api/passcode/email/route.ts
+++ b/src/app/api/passcode/email/route.ts
@@ -1,9 +1,12 @@
 import { getErrorMessage } from '@/common/common';
 import { assignPasscodeToEmail } from '@/db/services/PassCode/service';
+import { validateBearerToken } from '../../helpers';
 
 export async function PATCH(req: Request) {
-  const { email } = await req.json();
+  if (!validateBearerToken())
+    return new Response('Unauthorized', { status: 403 });
   try {
+    const { email } = await req.json();
     const data = await assignPasscodeToEmail(email);
     if (!data.success) return new Response(data.message, { status: 400 });
     return Response.json(data);

--- a/src/app/api/passcode/email/route.ts
+++ b/src/app/api/passcode/email/route.ts
@@ -1,0 +1,14 @@
+import { getErrorMessage } from '@/common/common';
+import { assignPasscodeToEmail } from '@/db/services/PassCode/service';
+
+export async function PATCH(req: Request) {
+  const { email } = await req.json();
+  try {
+    const data = await assignPasscodeToEmail(email);
+    if (!data.success) return new Response(data.message, { status: 400 });
+    return Response.json(data);
+  } catch (error) {
+    console.error('Error getting passcode for email. ', getErrorMessage(error));
+    return new Response('Something went wrong', { status: 500 });
+  }
+}

--- a/src/app/api/passcode/route.ts
+++ b/src/app/api/passcode/route.ts
@@ -11,9 +11,9 @@ export async function POST(req: Request) {
   //     return Response.json({ error: 'Unauthorized' }, { status: 403 });
   //   }
   try {
-    const { source } = await req.json();
+    const { source, quantity } = await req.json();
     if (!source) return new Response('Source is required', { status: 400 });
-    const data = await createPasscodes(source);
+    const data = await createPasscodes(source, quantity);
     if (!data.success) return new Response(data.message, { status: 400 });
     return Response.json(data);
   } catch (error) {

--- a/src/app/api/passcode/route.ts
+++ b/src/app/api/passcode/route.ts
@@ -1,0 +1,23 @@
+import { getErrorMessage } from '@/common/common';
+import { createPasscodes } from '@/db/services/PassCode/service';
+// import { headers } from 'next/headers';
+
+export async function POST(req: Request) {
+  //   console.log('req', req.body);
+  //   const headersList = headers();
+  //   const token = headersList.get('Authorization')?.split(' ')[1] || '';
+
+  //   if (token !== process.env.INTERNAL_API_KEY) {
+  //     return Response.json({ error: 'Unauthorized' }, { status: 403 });
+  //   }
+  try {
+    const { source } = await req.json();
+    if (!source) return new Response('Source is required', { status: 400 });
+    const data = await createPasscodes(source);
+    if (!data.success) return new Response(data.message, { status: 400 });
+    return Response.json(data);
+  } catch (error) {
+    console.error('Error getting passcode for email. ', getErrorMessage(error));
+    return new Response('Something went wrong', { status: 500 });
+  }
+}

--- a/src/app/api/passcode/route.ts
+++ b/src/app/api/passcode/route.ts
@@ -1,15 +1,11 @@
 import { getErrorMessage } from '@/common/common';
 import { createPasscodes } from '@/db/services/PassCode/service';
-// import { headers } from 'next/headers';
+import { validateBearerToken } from '../helpers';
 
 export async function POST(req: Request) {
-  //   console.log('req', req.body);
-  //   const headersList = headers();
-  //   const token = headersList.get('Authorization')?.split(' ')[1] || '';
+  if (!validateBearerToken())
+    return new Response('Unauthorized', { status: 403 });
 
-  //   if (token !== process.env.INTERNAL_API_KEY) {
-  //     return Response.json({ error: 'Unauthorized' }, { status: 403 });
-  //   }
   try {
     const { source, quantity } = await req.json();
     if (!source) return new Response('Source is required', { status: 400 });

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,10 +1,18 @@
 'use client';
 import Typography from '@mui/material/Typography';
 import MuiAlert from '@mui/material/Alert';
+import { useTheme } from '@mui/material/styles';
 
 export default function Alert({ messages }: { messages: string }): JSX.Element {
+  const theme = useTheme();
+  const isDarkMode = theme.palette.mode === 'dark';
+
   return (
-    <MuiAlert sx={{ width: '100%' }} severity="error">
+    <MuiAlert
+      sx={{ width: '100%' }}
+      severity="error"
+      variant={isDarkMode ? 'filled' : 'standard'}
+    >
       <Typography>{messages}</Typography>
     </MuiAlert>
   );

--- a/src/db/services/PassCode/model.ts
+++ b/src/db/services/PassCode/model.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema } from 'mongoose';
+
+export type PasscodeRecord = {
+  code: string;
+  email: string | null;
+  isUsed: boolean;
+  source: string;
+  createdAt: Date;
+};
+
+const passcodeSchema = new Schema<PasscodeRecord>(
+  {
+    code: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    email: {
+      type: String,
+      default: null,
+    },
+    isUsed: {
+      type: Boolean,
+      default: false,
+    },
+    source: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const Passcode: mongoose.Model<PasscodeRecord> =
+  mongoose.models.Passcode ||
+  mongoose.model<PasscodeRecord>('Passcode', passcodeSchema);
+
+export default Passcode;

--- a/src/db/services/PassCode/service.ts
+++ b/src/db/services/PassCode/service.ts
@@ -1,0 +1,91 @@
+import Passcode from './model';
+import dbConnect from '@/lib/dbConnect';
+import { nanoid } from 'nanoid';
+
+export async function createPasscode(
+  source: string,
+): Promise<{ success: boolean; message: string }> {
+  try {
+    await dbConnect();
+    await Passcode.create({
+      code: nanoid(6).toUpperCase(),
+      isUsed: false,
+      email: null,
+      source: source,
+    });
+    return { success: true, message: 'Passcode created successfully.' };
+  } catch (error) {
+    if (error instanceof Error) {
+      return { success: false, message: error.message };
+    }
+    return { success: false, message: 'An error occurred.' };
+  }
+}
+
+export async function verifyPasscode(
+  code: string,
+  email: string,
+): Promise<{ success: boolean; message: string }> {
+  try {
+    await dbConnect();
+    const passcodeEntry = await Passcode.findOne({
+      code,
+    });
+
+    if (!passcodeEntry) {
+      return { success: false, message: 'Passcode not found.' };
+    }
+
+    if (passcodeEntry.isUsed) {
+      if (passcodeEntry.email === email) {
+        return { success: true, message: 'Access granted.' };
+      } else {
+        return {
+          success: false,
+          message: 'Access denied. Email does not match.',
+        };
+      }
+    }
+    return { success: false, message: 'Passcode or email incorrect.' };
+  } catch (error) {
+    if (error instanceof Error) {
+      return { success: false, message: error.message };
+    }
+    return { success: false, message: 'An error occurred.' };
+  }
+}
+
+export async function assignPasscodeToEmail(email: string) {
+  try {
+    await dbConnect();
+
+    const existingPasscode = await Passcode.findOne({ email }).lean();
+    if (existingPasscode) {
+      return {
+        success: false,
+        message: 'Email already has an assigned passcode.',
+      };
+    }
+
+    const availablePasscode = await Passcode.findOne({ isUsed: false });
+    if (!availablePasscode) {
+      return { success: false, message: 'No available passcodes.' };
+    }
+
+    availablePasscode.email = email;
+    availablePasscode.isUsed = true;
+    await availablePasscode.save();
+
+    return {
+      success: true,
+      message: 'Email assigned to passcode successfully.',
+      code: availablePasscode.code,
+      email: availablePasscode.email,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : 'An error occurred.',
+    };
+  }
+}

--- a/src/db/services/PassCode/service.ts
+++ b/src/db/services/PassCode/service.ts
@@ -2,18 +2,20 @@ import Passcode from './model';
 import dbConnect from '@/lib/dbConnect';
 import { nanoid } from 'nanoid';
 
-export async function createPasscode(
+export async function createPasscodes(
   source: string,
+  numberOfPasscodes: number = 1,
 ): Promise<{ success: boolean; message: string }> {
   try {
     await dbConnect();
-    await Passcode.create({
+    const passcodes = Array.from({ length: numberOfPasscodes }, () => ({
       code: nanoid(6).toUpperCase(),
       isUsed: false,
       email: null,
       source: source,
-    });
-    return { success: true, message: 'Passcode created successfully.' };
+    }));
+    await Passcode.insertMany(passcodes);
+    return { success: true, message: 'Passcodes created successfully.' };
   } catch (error) {
     if (error instanceof Error) {
       return { success: false, message: error.message };

--- a/src/db/services/PassCode/service.ts
+++ b/src/db/services/PassCode/service.ts
@@ -4,18 +4,24 @@ import { nanoid } from 'nanoid';
 
 export async function createPasscodes(
   source: string,
-  numberOfPasscodes: number = 1,
+  quantity: number = 1,
 ): Promise<{ success: boolean; message: string }> {
   try {
     await dbConnect();
-    const passcodes = Array.from({ length: numberOfPasscodes }, () => ({
+    if (!source) {
+      return { success: false, message: 'Source is required.' };
+    }
+    const passcodes = Array.from({ length: quantity }, () => ({
       code: nanoid(6).toUpperCase(),
       isUsed: false,
       email: null,
       source: source,
     }));
     await Passcode.insertMany(passcodes);
-    return { success: true, message: 'Passcodes created successfully.' };
+    return {
+      success: true,
+      message: `${passcodes.length} passcodes created successfully.`,
+    };
   } catch (error) {
     if (error instanceof Error) {
       return { success: false, message: error.message };

--- a/src/intl/cbuilder.json
+++ b/src/intl/cbuilder.json
@@ -90,6 +90,13 @@
       "cancelButton": "CANCEL",
       "forgotPassword": "FORGOT PASSWORD?",
       "errorMessage": "Wrong email or password"
+    },
+    "PassCode": {
+      "emailHelperText": "Enter your Cboard account email",
+      "invalidCredentials": "Invalid code or email",
+      "code": "Code",
+      "email": "Email",
+      "submit": "SUBMIT"
     }
   },
   "Settings": {


### PR DESCRIPTION
## Changes Included:
- **Style Fixes**: Updated the styles for the sign-in page to improve appearance in dark mode.
- **Authorization Step**: Added an authorization step before accessing the login form. In this new step, users must provide a passcode and email to proceed.
- **Signup Navigation**: The "Sign Up" button now directs users to the Cboard Sign-Up page.

## New Endpoints:
1. **POST `api/passcode`**: Creates new passcodes in the database.
   - **Authorization**: Requires a Bearer Token in the Auth header.
   - **Request Body**:
   ```json
   {
     "source": "closingTheGap",  // required - Indicates the source where the user obtained the passcode.
     "quantity": "3"  // optional, default is 1 - Number of passcodes to create.
   }

2. **PATCH `api/passcode/email`**:  Associates an existing passcode with an email.
   - **Authorization**: Requires a Bearer Token in the Auth header.
   - **Request Body**:
```json
"email": "pepe@gmail.com" // Email to associate a passcode
```